### PR TITLE
Update build.gradle and gradle-wrapper.properties

### DIFF
--- a/playground/android/build.gradle
+++ b/playground/android/build.gradle
@@ -7,15 +7,22 @@ buildscript {
         compileSdkVersion = 28
         targetSdkVersion = 28
     }
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath("com.android.tools.build:gradle:3.4.2")
+    /**
+     * The Android Gradle plugin is only required when opening this project stand-alone.
+     * This avoids unnecessary downloads and potential conflicts when the library is included as a
+     * module dependency in an application project.
+     * */
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
+        dependencies {
+            classpath("com.android.tools.build:gradle:3.5.1")
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+            // NOTE: Do not place your application dependencies here; they belong
+            // in the individual module build.gradle files
+        }
     }
 }
 

--- a/playground/android/gradle/wrapper/gradle-wrapper.properties
+++ b/playground/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Conditionally loading Android Gradle Plugin to avoid using this library's AGP when it used as a submodule.

for more information, you can read [this thread](https://github.com/facebook/react-native/pull/25569) and [this solution](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277).

Also it worth to take a look at [this conversion](https://github.com/react-native-community/discussions-and-proposals/issues/151).