### PR TITLE
add header border width to the options

### DIFF
--- a/src/datePicker/DatePicker.js
+++ b/src/datePicker/DatePicker.js
@@ -114,6 +114,7 @@ const optionsShape = {
   mainColor: PropTypes.string,
   textSecondaryColor: PropTypes.string,
   borderColor: PropTypes.string,
+  headerBorderWidth: PropTypes.number,
   defaultFont: PropTypes.string,
   headerFont: PropTypes.string,
   textFontSize: PropTypes.number,

--- a/src/datePicker/components/Header.js
+++ b/src/datePicker/components/Header.js
@@ -66,7 +66,7 @@ const Header = ({changeMonth}) => {
           ]}>
           <TouchableOpacity
             activeOpacity={0.7}
-            style={[style.centerWrapper, style.monthYearWrapper, utils.flexDirection]}
+            style={[options.headerBorderWidth ? style.centerWrapper : style.centerWrapperWithoutBorder, style.monthYearWrapper, utils.flexDirection]}
             onPress={() =>
               !disableDateChange &&
               setMainState({
@@ -84,7 +84,7 @@ const Header = ({changeMonth}) => {
             <TouchableOpacity
               activeOpacity={0.7}
               style={[
-                style.centerWrapper,
+                options.headerBorderWidth ? style.centerWrapper : style.centerWrapperWithoutBorder,
                 {marginRight: I18nManager.isRTL ? 0 : 5, marginLeft: I18nManager.isRTL ? 5 : 0},
               ]}
               onPress={() =>
@@ -195,7 +195,12 @@ const styles = (theme) =>
       paddingHorizontal: 8,
       alignItems: 'center',
       borderRadius: 5,
-      borderWidth: 1,
+      borderWidth: theme.headerBorderWidth,
+    },
+    centerWrapperWithoutBorder: {
+      paddingVertical: 4,
+      paddingHorizontal: 8,
+      alignItems: 'center',
     },
     time: {
       marginRight: 5,


### PR DESCRIPTION
I'm using this perfect package in my project and I faced to a missing style option that was borderWidth of header calendar and I really needed it (maybe others also have this problem :) ).
So  I decided to add this option to the package
![Screen Shot 2022-09-19 at 4 02 12 PM](https://user-images.githubusercontent.com/57182874/191008552-e91b28c9-4cc7-4e07-b6fa-dea3ff6ad34c.png)
![Screen Shot 2022-09-19 at 4 04 30 PM](https://user-images.githubusercontent.com/57182874/191008563-18cf0d7f-413a-4595-8bb8-49f085f07335.png)
you can easily add border (by adding some value) or remove border (by default there is no border)
it would be perfect if it's not follow your structure, add it on your own with your principles 🙏🏼