### PR TITLE
Removed Default Props for Newer React

### DIFF
--- a/src/datePicker/DatePicker.js
+++ b/src/datePicker/DatePicker.js
@@ -41,20 +41,42 @@ const useCalendar = () => {
   return contextValue;
 };
 
-const DatePicker = props => {
-  const calendarUtils = new utils(props);
+const DatePicker = ({
+  onSelectedChange = () => null,
+  onMonthYearChange = () => null,
+  onTimeChange = () => null,
+  onDateChange = () => null,
+  current = '',
+  selected = '',
+  minimumDate = '',
+  maximumDate = '',
+  selectorStartingYear = 0,
+  selectorEndingYear = 3000,
+  disableDateChange = false,
+  isGregorian = true,
+  configs = {},
+  reverse = 'unset',
+  options = {},
+  mode = 'datepicker',
+  minuteInterval = 5,
+  style = {},
+}) => {
+  const calendarUtils = new utils({ current, selected, minimumDate, maximumDate, ...configs });
   const contextValue = {
-    ...props,
-    reverse: props.reverse === 'unset' ? !props.isGregorian : props.reverse,
-    options: {...options, ...props.options},
+    onSelectedChange,
+    onMonthYearChange,
+    onTimeChange,
+    onDateChange,
+    reverse: reverse === 'unset' ? !isGregorian : reverse,
+    options: {...options, ...options},
     utils: calendarUtils,
     state: useReducer(reducer, {
-      activeDate: props.current || calendarUtils.getToday(),
-      selectedDate: props.selected
-        ? calendarUtils.getFormated(calendarUtils.getDate(props.selected))
+      activeDate: current || calendarUtils.getToday(),
+      selectedDate: selected
+        ? calendarUtils.getFormated(calendarUtils.getDate(selected))
         : '',
-      monthOpen: props.mode === 'monthYear',
-      timeOpen: props.mode === 'time',
+      monthOpen: mode === 'monthYear',
+      timeOpen: mode === 'time',
     }),
   };
   const [minHeight, setMinHeight] = useState(300);
@@ -88,7 +110,7 @@ const DatePicker = props => {
   return (
     <CalendarContext.Provider value={contextValue}>
       <View
-        style={[style.container, {minHeight}, props.style]}
+        style={[style.container, {minHeight}, style]}
         onLayout={({nativeEvent}) => setMinHeight(nativeEvent.layout.width * 0.9 + 55)}>
         {renderBody()}
       </View>
@@ -123,27 +145,6 @@ const optionsShape = {
 };
 const modeArray = ['datepicker', 'calendar', 'monthYear', 'time'];
 const minuteIntervalArray = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60];
-
-DatePicker.defaultProps = {
-  onSelectedChange: () => null,
-  onMonthYearChange: () => null,
-  onTimeChange: () => null,
-  onDateChange: () => null,
-  current: '',
-  selected: '',
-  minimumDate: '',
-  maximumDate: '',
-  selectorStartingYear: 0,
-  selectorEndingYear: 3000,
-  disableDateChange: false,
-  isGregorian: true,
-  configs: {},
-  reverse: 'unset',
-  options: {},
-  mode: 'datepicker',
-  minuteInterval: 5,
-  style: {},
-};
 
 DatePicker.propTypes = {
   onSelectedChange: PropTypes.func,

--- a/src/datePicker/components/Header.js
+++ b/src/datePicker/components/Header.js
@@ -4,7 +4,8 @@ import {View, TouchableOpacity, Text, Image, StyleSheet, Animated, I18nManager} 
 
 import {useCalendar} from '../DatePicker';
 
-const Header = ({changeMonth}) => {
+// Use JavaScript default parameters to handle default values
+const Header = ({changeMonth = () => null}) => {
   const {
     options,
     disableDateChange,
@@ -201,11 +202,6 @@ const styles = (theme) =>
       marginRight: 5,
     },
   });
-
-Header.defaultProps = {
-  changeMonth: () => null,
-};
-
 Header.propTypes = {
   changeMonth: PropTypes.func,
 };

--- a/website/src/components/seo.js
+++ b/website/src/components/seo.js
@@ -12,7 +12,7 @@ import {useStaticQuery, graphql} from 'gatsby';
 
 import logoFavIcon from '../assets/images/favicon.png';
 
-function SEO({description, lang, meta, title}) {
+function SEO({description = '', lang = 'en', meta = [], title}) {
   const {site} = useStaticQuery(
     graphql`
       query {
@@ -86,12 +86,6 @@ function SEO({description, lang, meta, title}) {
     </Helmet>
   );
 }
-
-SEO.defaultProps = {
-  lang: `en`,
-  meta: [],
-  description: ``,
-};
 
 SEO.propTypes = {
   description: PropTypes.string,


### PR DESCRIPTION
I was getting this error in my React Native project -- 

ERROR  Warning: Header: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.

 in Header (created by Calendar)
    in RCTView (created by View)
    in View (created by Calendar)
    in Calendar (created by DatePicker)