### PR TITLE
Replace defaultProps with defaultParameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-native-modern-datepicker",
-  "version": "1.0.0-beta.91",
-  "description": "A customizable calendar, time & month picker for React Native (including Persian Jalaali calendar & locale)",
+  "name": "react-native-modern-datepicker-forked",
+  "version": "1.0.0",
+  "description": "A customizable calendar, time & month picker for React Native (including Persian Jalaali calendar & locale) - Forked",
   "main": "src/index.js",
   "scripts": {
     "playground": "cd playground && react-native start"
@@ -9,16 +9,21 @@
   "files": [
     "src"
   ],
-  "author": "Hossein Shabani",
+  "author": "Noah Vikoo",
+   "original-author": [
+    {
+      "name": "Hossein Shabani",
+      "url": "https://github.com/HosseinShabani/react-native-modern-datepicker.git"
+    }
+  ],
   "homepage": "https://hosseinshabani.github.io/react-native-modern-datepicker/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/HosseinShabani/react-native-modern-datepicker.git"
+    "url": "https://github.com/Noah-V/react-native-modern-datepicker"
   },
   "bugs": {
     "url": "https://github.com/HosseinShabani/react-native-modern-datepicker/issues"
   },
-  "license": "MIT",
   "keywords": [
     "react",
     "react-native",

--- a/src/datePicker/DatePicker.js
+++ b/src/datePicker/DatePicker.js
@@ -1,4 +1,4 @@
-import React, {createContext, useReducer, useContext, useState} from 'react';
+import React, {createContext, useReducer, useContext, useState, useEffect} from 'react';
 import {View, StyleSheet} from 'react-native';
 import PropTypes from 'prop-types';
 
@@ -56,31 +56,32 @@ const DatePicker = ({
   isGregorian = true,
   configs = {},
   reverse = 'unset',
-  options: {},
+  options = {},
   mode = 'datepicker',
   minuteInterval = 5,
-  style = {},
- }) => {
-  const calendarUtils = new utils({
-    onSelectedChange, 
-    onMonthYearChange, 
-    onTimeChange, 
-    onDateChange, 
-    current, 
-    selected, 
-    minimumDate, 
-    maximumDate, 
-    selectorStartingYear, 
-    selectorEndingYear, 
-    disableDateChange, 
-    isGregorian, 
-    configs, 
-    reverse, 
-    options: userOptions, 
-    mode, 
-    minuteInterval, 
-    style 
+  _style = {},
+}) => {
+  const [props, setProps] = useState({
+    onSelectedChange,
+    onMonthYearChange,
+    onTimeChange,
+    onDateChange,
+    current,
+    selected,
+    minimumDate,
+    maximumDate,
+    selectorStartingYear,
+    selectorEndingYear,
+    disableDateChange,
+    isGregorian,
+    configs,
+    reverse,
+    options,
+    mode,
+    minuteInterval,
+    _style,
   });
+  const calendarUtils = new utils(props);
 
   const contextValue = {
     ...props,
@@ -163,26 +164,26 @@ const optionsShape = {
 const modeArray = ['datepicker', 'calendar', 'monthYear', 'time'];
 const minuteIntervalArray = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60];
 
-DatePicker.defaultProps = {
-  onSelectedChange: () => null,
-  onMonthYearChange: () => null,
-  onTimeChange: () => null,
-  onDateChange: () => null,
-  current: '',
-  selected: '',
-  minimumDate: '',
-  maximumDate: '',
-  selectorStartingYear: 0,
-  selectorEndingYear: 3000,
-  disableDateChange: false,
-  isGregorian: true,
-  configs: {},
-  reverse: 'unset',
-  options: {},
-  mode: 'datepicker',
-  minuteInterval: 5,
-  style: {},
-};
+// DatePicker.defaultProps = {
+//   onSelectedChange: () => null,
+//   onMonthYearChange: () => null,
+//   onTimeChange: () => null,
+//   onDateChange: () => null,
+//   current: '',
+//   selected: '',
+//   minimumDate: '',
+//   maximumDate: '',
+//   selectorStartingYear: 0,
+//   selectorEndingYear: 3000,
+//   disableDateChange: false,
+//   isGregorian: true,
+//   configs: {},
+//   reverse: 'unset',
+//   options: {},
+//   mode: 'datepicker',
+//   minuteInterval: 5,
+//   style: {},
+// };
 
 DatePicker.propTypes = {
   onSelectedChange: PropTypes.func,

--- a/src/datePicker/DatePicker.js
+++ b/src/datePicker/DatePicker.js
@@ -41,8 +41,47 @@ const useCalendar = () => {
   return contextValue;
 };
 
-const DatePicker = props => {
-  const calendarUtils = new utils(props);
+const DatePicker = ({
+  onSelectedChange = () => null,
+  onMonthYearChange = () => null,
+  onTimeChange = () => null,
+  onDateChange = () => null,
+  current = '',
+  selected = '',
+  minimumDate = '',
+  maximumDate = '',
+  selectorStartingYear = 0,
+  selectorEndingYear = 3000,
+  disableDateChange = false,
+  isGregorian = true,
+  configs = {},
+  reverse = 'unset',
+  options: {},
+  mode = 'datepicker',
+  minuteInterval = 5,
+  style = {},
+ }) => {
+  const calendarUtils = new utils({
+    onSelectedChange, 
+    onMonthYearChange, 
+    onTimeChange, 
+    onDateChange, 
+    current, 
+    selected, 
+    minimumDate, 
+    maximumDate, 
+    selectorStartingYear, 
+    selectorEndingYear, 
+    disableDateChange, 
+    isGregorian, 
+    configs, 
+    reverse, 
+    options: userOptions, 
+    mode, 
+    minuteInterval, 
+    style 
+  });
+
   const contextValue = {
     ...props,
     reverse: props.reverse === 'unset' ? !props.isGregorian : props.reverse,
@@ -96,7 +135,7 @@ const DatePicker = props => {
   );
 };
 
-const styles = theme =>
+const styles = (theme) =>
   StyleSheet.create({
     container: {
       backgroundColor: theme.backgroundColor,

--- a/src/datePicker/components/Header.js
+++ b/src/datePicker/components/Header.js
@@ -4,7 +4,7 @@ import {View, TouchableOpacity, Text, Image, StyleSheet, Animated, I18nManager} 
 
 import {useCalendar} from '../DatePicker';
 
-const Header = ({changeMonth}) => {
+const Header = ({changeMonth = () => null}) => {
   const {
     options,
     disableDateChange,
@@ -202,9 +202,9 @@ const styles = (theme) =>
     },
   });
 
-Header.defaultProps = {
-  changeMonth: () => null,
-};
+// Header.defaultProps = {
+//   changeMonth: () => null,
+// };
 
 Header.propTypes = {
   changeMonth: PropTypes.func,


### PR DESCRIPTION
This pull request updates the react-native-modern-datepicker library to use default parameters instead of defaultProps for functional components.